### PR TITLE
fix code sample to follow system theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
         def versionMajor = 1
         def versionMinor = 1
-        def versionPatch = 0
+        def versionPatch = 1
 
         applicationId "com.github.odaridavid.designpatterns"
         minSdkVersion 21
@@ -31,6 +31,8 @@ android {
             manifestPlaceholders = [crashlyticsEnabled: true]
         }
         debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
             manifestPlaceholders = [crashlyticsEnabled: false]
         }
     }

--- a/whatsnew/whatsnew-en-GB.txt
+++ b/whatsnew/whatsnew-en-GB.txt
@@ -1,2 +1,2 @@
-- Immediate In App Update Available
-- Adds a Dark theme variant
+- Fix code sample not switching to a dark theme on system-related theme change.
+- Minor bug fixes and improvements.


### PR DESCRIPTION
The dark theme wasn't taking effect on the code sample when the preference was set to auto battery or system default.